### PR TITLE
Chain validation & AS validation fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,7 @@ config.log
 config.status
 stamp-h1
 .deps/*
+
+# compilation artifacts
+libopenarc/symbols.map
+openarc/.libs/

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,9 @@ config.log
 config.status
 stamp-h1
 .deps/*
+*~
+*.cache
+*#*
 
 # compilation artifacts
 libopenarc/symbols.map

--- a/libopenarc/arc-canon.c
+++ b/libopenarc/arc-canon.c
@@ -1157,8 +1157,8 @@ arc_canon_runheaders_seal(ARC_MESSAGE *msg)
 			}
 			else
 			{
-        arc_canon_strip_b(msg, msg->arc_sets[m].arcset_as->hdr_text);
 				struct arc_hdrfield tmphdr;
+				arc_canon_strip_b(msg, msg->arc_sets[m].arcset_as->hdr_text);
 
 				tmphdr.hdr_text = arc_dstring_get(msg->arc_hdrbuf);
 				tmphdr.hdr_namelen = cur->canon_sigheader->hdr_namelen;
@@ -1178,9 +1178,8 @@ arc_canon_runheaders_seal(ARC_MESSAGE *msg)
 				return status;
 		}
 
-    arc_canon_finalize(cur);
-
-    cur->canon_done = TRUE;
+		arc_canon_finalize(cur);
+		cur->canon_done = TRUE;
 
 		cur = msg->arc_sealcanon;
 

--- a/libopenarc/arc-canon.c
+++ b/libopenarc/arc-canon.c
@@ -265,7 +265,6 @@ arc_canon_header_string(struct arc_dstring *dstr, arc_canon_t canon,
 	u_char *tmp;
 	u_char *end;
 	u_char tmpbuf[BUFRSZ];
-
 	assert(dstr != NULL);
 	assert(hdr != NULL);
 
@@ -317,7 +316,7 @@ arc_canon_header_string(struct arc_dstring *dstr, arc_canon_t canon,
 
 				tmp = tmpbuf;
 			}
-			
+
 			if (*p == ':')
 			{
 				p++;
@@ -440,6 +439,7 @@ arc_canon_header(ARC_MESSAGE *msg, ARC_CANON *canon, struct arc_hdrfield *hdr,
 	status = arc_canon_header_string(msg->arc_canonbuf, canon->canon_canon,
 	                                 hdr->hdr_text, hdr->hdr_textlen,
 	                                 crlf);
+
 	if (status != ARC_STAT_OK)
 		return status;
 
@@ -696,7 +696,6 @@ arc_canon_cleanup(ARC_MESSAGE *msg)
 **
 **  Parameters:
 **  	msg -- verification handle
-**  	hdr -- TRUE iff this is specifying a header canonicalization
 **  	type -- an ARC_CANONTYPE_* constant
 **  	canon -- arc_canon_t
 **  	hashtype -- hash type
@@ -1158,6 +1157,7 @@ arc_canon_runheaders_seal(ARC_MESSAGE *msg)
 			}
 			else
 			{
+        arc_canon_strip_b(msg, msg->arc_sets[m].arcset_as->hdr_text);
 				struct arc_hdrfield tmphdr;
 
 				tmphdr.hdr_text = arc_dstring_get(msg->arc_hdrbuf);
@@ -1479,7 +1479,7 @@ arc_canon_signature(ARC_MESSAGE *msg, struct arc_hdrfield *hdr, _Bool seal)
 		tmphdr.hdr_flags = 0;
 		tmphdr.hdr_next = NULL;
 		arc_lowerhdr(tmphdr.hdr_text);
-		
+
 		/* canonicalize the signature */
 		status = arc_canon_header(msg, cur, &tmphdr, FALSE);
 		if (status != ARC_STAT_OK)

--- a/libopenarc/arc-canon.c
+++ b/libopenarc/arc-canon.c
@@ -1176,11 +1176,11 @@ arc_canon_runheaders_seal(ARC_MESSAGE *msg)
 
 			if (status != ARC_STAT_OK)
 				return status;
-
-			arc_canon_finalize(cur);
-
-			cur->canon_done = TRUE;
 		}
+
+    arc_canon_finalize(cur);
+
+    cur->canon_done = TRUE;
 
 		cur = msg->arc_sealcanon;
 

--- a/libopenarc/arc.c
+++ b/libopenarc/arc.c
@@ -331,7 +331,7 @@ arc_genamshdr(ARC_MESSAGE *msg, struct arc_dstring *dstr, char *delim,
 		format = "i=%u;%sa=%s;%sd=%s;%ss=%s;%st=%llu";
 	else if (sizeof(msg->arc_timestamp) == sizeof(unsigned long))
 		format = "i=%u;%sa=%s;%sd=%s;%ss=%s;%st=%lu";
-	else 
+	else
 		format = "i=%u;%sa=%s;%sd=%s;%ss=%s;%st=%u";
 
 
@@ -700,7 +700,7 @@ arc_getamshdr_d(ARC_MESSAGE *msg, size_t initial, u_char **buf, size_t *buflen,
 						                  n);
 						x += n;
 						len += n;
-						
+
 					}
 				}
 				else
@@ -825,7 +825,7 @@ arc_geterror(ARC_MESSAGE *msg)
 }
 
 /*
-** 
+**
 **  ARC_OPTIONS -- get/set library options
 **
 **  Parameters:
@@ -1473,7 +1473,7 @@ arc_process_set(ARC_MESSAGE *msg, arc_kvsettype_t type, u_char *str,
 		}
 
 		/* test validity of "t", "x", and "i" */
-		
+
 		p = arc_param_get(set, (u_char *) "t");
 		if (p != NULL && !arc_check_uint(p))
 		{
@@ -1524,7 +1524,7 @@ arc_process_set(ARC_MESSAGE *msg, arc_kvsettype_t type, u_char *str,
 		}
 
 		break;
-			
+
 	  /* these have no defaults */
 	  case ARC_KVSETTYPE_SEAL:
 		/* make sure required stuff is here */
@@ -2548,66 +2548,60 @@ arc_body(ARC_MESSAGE *msg, u_char *buf, size_t len)
 ARC_STAT
 arc_eom(ARC_MESSAGE *msg)
 {
-	/*
-	**  Verify the exisitng chain, if any.
-	*/
+  /*
+  **  Verify the exisitng chain, if any.
+  */
 
-	if (msg->arc_nsets == 0)
-	{
-		msg->arc_cstate = ARC_CHAIN_NONE;
-	}
-	else
-	{
-		u_int set;
+  if (msg->arc_nsets == 0)
+  {
+    msg->arc_cstate = ARC_CHAIN_NONE;
+  }
+  else
+  {
+    /* validate the final ARC-Message-Signature */
+    if (arc_validate_msg(msg, msg->arc_nsets) != ARC_STAT_OK)
+    {
+      msg->arc_cstate = ARC_CHAIN_FAIL;
+    }
+    else
+    {
+      u_int set;
+      u_char *inst;
+      u_char *cv;
+      ARC_KVSET *kvset;
 
-		/* validate the final ARC-Message-Signature */
-		if (arc_validate_msg(msg, msg->arc_nsets) == ARC_STAT_BADSIG)
-		{
-			msg->arc_cstate = ARC_CHAIN_FAIL;
-		}
-		else
-		{
-			u_char *inst;
-			u_char *cv;
-			ARC_KVSET *kvset;
+      msg->arc_cstate = ARC_CHAIN_PASS;
+      for (set = msg->arc_nsets; set > 0; set--)
+      {
+        for (kvset = arc_set_first(msg,
+                                   ARC_KVSETTYPE_SEAL);
+            kvset != NULL;
+            kvset = arc_set_next(kvset,
+                                 ARC_KVSETTYPE_SEAL))
+        {
+          inst = arc_param_get(kvset, "i");
+          if (atoi(inst) == set)
+            break;
+        }
 
-			for (set = msg->arc_nsets; set > 0; set--)
-			{
-				for (kvset = arc_set_first(msg,
-				                           ARC_KVSETTYPE_SEAL);
-				    kvset != NULL;
-				    kvset = arc_set_next(kvset,
-				                         ARC_KVSETTYPE_SEAL))
-				{
-					inst = arc_param_get(kvset, "i");
-					if (atoi(inst) == set)
-						break;
-				}
+        cv = arc_param_get(kvset, "cv");
+        if (!((set == 1 && strcasecmp(cv, "none") == 0) ||
+              (set != 1 && strcasecmp(cv, "pass") == 0)))
+          {
+            msg->arc_cstate = ARC_CHAIN_FAIL;
+            break;
+          }
 
-				cv = arc_param_get(kvset, "cv");
-				if ((set == 1 && strcasecmp(cv, "none") == 0) ||
-				    (set != 1 && strcasecmp(cv, "pass") == 0))
-				{
-					ARC_STAT status;
+        if (arc_validate_seal(msg, set) != ARC_STAT_OK)
+          {
+            msg->arc_cstate = ARC_CHAIN_FAIL;
+            break;
+          }
+      }
+    }
+  }
 
-					status = arc_validate_seal(msg, set);
-					if (status == ARC_STAT_BADSIG)
-					{
-						msg->arc_cstate = ARC_CHAIN_FAIL;
-						break;
-					}
-					else if (status != ARC_STAT_OK)
-					{
-						return status;
-					}
-				}
-			}
-		}
-
-		msg->arc_cstate = ARC_CHAIN_PASS;
-	}
-
-	return ARC_STAT_OK;
+  return ARC_STAT_OK;
 }
 
 /*
@@ -2738,7 +2732,7 @@ arc_getseal(ARC_MESSAGE *msg, ARC_HDRFIELD **seal, char *authservid,
 		msg->arc_sealhead = NULL;
 		msg->arc_sealtail = NULL;
 	}
-	
+
 	/*
 	**  Part 1: Construct a new AAR
 	*/
@@ -2762,7 +2756,7 @@ arc_getseal(ARC_MESSAGE *msg, ARC_HDRFIELD **seal, char *authservid,
 
 	msg->arc_sealhead = h;
 	msg->arc_sealtail = h;
-	
+
 	/*
 	**  Part B: Construct a new AMS (basically a no-frills DKIM signature)
 	*/

--- a/libopenarc/arc.c
+++ b/libopenarc/arc.c
@@ -2548,60 +2548,60 @@ arc_body(ARC_MESSAGE *msg, u_char *buf, size_t len)
 ARC_STAT
 arc_eom(ARC_MESSAGE *msg)
 {
-  /*
-  **  Verify the exisitng chain, if any.
-  */
+	/*
+	**  Verify the exisitng chain, if any.
+	*/
 
-  if (msg->arc_nsets == 0)
-  {
-    msg->arc_cstate = ARC_CHAIN_NONE;
-  }
-  else
-  {
-    /* validate the final ARC-Message-Signature */
-    if (arc_validate_msg(msg, msg->arc_nsets) != ARC_STAT_OK)
-    {
-      msg->arc_cstate = ARC_CHAIN_FAIL;
-    }
-    else
-    {
-      u_int set;
-      u_char *inst;
-      u_char *cv;
-      ARC_KVSET *kvset;
+	if (msg->arc_nsets == 0)
+	{
+		msg->arc_cstate = ARC_CHAIN_NONE;
+	}
+	else
+	{
+		/* validate the final ARC-Message-Signature */
+		if (arc_validate_msg(msg, msg->arc_nsets) != ARC_STAT_OK)
+		{
+			msg->arc_cstate = ARC_CHAIN_FAIL;
+		}
+		else
+		{
+			u_int set;
+			u_char *inst;
+			u_char *cv;
+			ARC_KVSET *kvset;
 
-      msg->arc_cstate = ARC_CHAIN_PASS;
-      for (set = msg->arc_nsets; set > 0; set--)
-      {
-        for (kvset = arc_set_first(msg,
-                                   ARC_KVSETTYPE_SEAL);
-            kvset != NULL;
-            kvset = arc_set_next(kvset,
-                                 ARC_KVSETTYPE_SEAL))
-        {
-          inst = arc_param_get(kvset, "i");
-          if (atoi(inst) == set)
-            break;
-        }
+			msg->arc_cstate = ARC_CHAIN_PASS;
+			for (set = msg->arc_nsets; set > 0; set--)
+			{
+				for (kvset = arc_set_first(msg,
+																	 ARC_KVSETTYPE_SEAL);
+						kvset != NULL;
+						kvset = arc_set_next(kvset,
+																 ARC_KVSETTYPE_SEAL))
+				{
+					inst = arc_param_get(kvset, "i");
+					if (atoi(inst) == set)
+						break;
+				}
 
-        cv = arc_param_get(kvset, "cv");
-        if (!((set == 1 && strcasecmp(cv, "none") == 0) ||
-              (set != 1 && strcasecmp(cv, "pass") == 0)))
-          {
-            msg->arc_cstate = ARC_CHAIN_FAIL;
-            break;
-          }
+				cv = arc_param_get(kvset, "cv");
+				if (!((set == 1 && strcasecmp(cv, "none") == 0) ||
+							(set != 1 && strcasecmp(cv, "pass") == 0)))
+					{
+						msg->arc_cstate = ARC_CHAIN_FAIL;
+						break;
+					}
 
-        if (arc_validate_seal(msg, set) != ARC_STAT_OK)
-          {
-            msg->arc_cstate = ARC_CHAIN_FAIL;
-            break;
-          }
-      }
-    }
-  }
+				if (arc_validate_seal(msg, set) != ARC_STAT_OK)
+					{
+						msg->arc_cstate = ARC_CHAIN_FAIL;
+						break;
+					}
+			}
+		}
+	}
 
-  return ARC_STAT_OK;
+	return ARC_STAT_OK;
 }
 
 /*

--- a/libopenarc/arc.c
+++ b/libopenarc/arc.c
@@ -2410,7 +2410,7 @@ arc_eoh(ARC_MESSAGE *msg)
 	htag = NULL;
 	if (nsets > 0)
 	{
-		h = msg->arc_sets[n - 1].arcset_ams;
+		h = msg->arc_sets[nsets - 1].arcset_ams;
 		htag = arc_param_get(h->hdr_data, "h");
 	}
 	status = arc_add_canon(msg, ARC_CANONTYPE_HEADER, msg->arc_canonhdr,

--- a/libopenarc/arc.h
+++ b/libopenarc/arc.h
@@ -300,7 +300,7 @@ void arc_error __P((ARC_MESSAGE *, const char *, ...));
 **  	A new library instance.
 */
 
-ARC_LIB *arc_init(void);
+extern ARC_LIB *arc_init (void);
 
 /*
 **  ARC_CLOSE -- terminate a library instance
@@ -312,7 +312,7 @@ ARC_LIB *arc_init(void);
 **  	None.
 */
 
-void arc_close(ARC_LIB *);
+extern void arc_close (ARC_LIB *);
 
 /*
 **  ARC_GETERROR -- return any stored error string from within the DKIM
@@ -343,7 +343,7 @@ extern const char *arc_geterror __P((ARC_MESSAGE *));
 **  	argument.
 */
 
-ARC_STAT arc_options(ARC_LIB *, int, int, void *, size_t);
+extern ARC_STAT arc_options (ARC_LIB *, int, int, void *, size_t);
 
 /*
 **  ARC_GETSSLBUF -- retrieve SSL error buffer
@@ -371,8 +371,8 @@ const char *arc_getsslbuf(ARC_LIB *);
 **  	A new message instance, or NULL on failure (and "err" is updated).
 */
 
-ARC_MESSAGE *arc_message(ARC_LIB *, arc_canon_t, arc_canon_t, arc_alg_t,
-                         const u_char **);
+extern ARC_MESSAGE *arc_message (ARC_LIB *, arc_canon_t, arc_canon_t,
+				 arc_alg_t, const u_char **);
 
 /*
 **  ARC_FREE -- deallocate a message object
@@ -384,7 +384,7 @@ ARC_MESSAGE *arc_message(ARC_LIB *, arc_canon_t, arc_canon_t, arc_alg_t,
 **  	None.
 */
 
-void arc_free(ARC_MESSAGE *);
+extern void arc_free (ARC_MESSAGE *);
 
 /*
 **  ARC_HEADER_FIELD -- consume a header field
@@ -398,7 +398,7 @@ void arc_free(ARC_MESSAGE *);
 **  	An ARC_STAT_* constant.
 */
 
-ARC_STAT arc_header_field(ARC_MESSAGE *, u_char *, size_t);
+extern ARC_STAT arc_header_field (ARC_MESSAGE *, u_char *, size_t);
 
 /*
 **  ARC_EOH -- declare no more headers are coming
@@ -413,7 +413,7 @@ ARC_STAT arc_header_field(ARC_MESSAGE *, u_char *, size_t);
 **  	This can probably be merged with arc_eom().
 */
 
-ARC_STAT arc_eoh(ARC_MESSAGE *);
+extern ARC_STAT arc_eoh (ARC_MESSAGE *);
 
 /*
 **  ARC_BODY -- process a body chunk
@@ -439,7 +439,7 @@ extern ARC_STAT arc_body __P((ARC_MESSAGE *msg, u_char *buf, size_t len));
 **  	An ARC_STAT_* constant.
 */
 
-ARC_STAT arc_eom(ARC_MESSAGE *);
+extern ARC_STAT arc_eom (ARC_MESSAGE *);
 
 /*
 **  ARC_GETSEAL -- get the "seal" to apply to this message
@@ -462,8 +462,8 @@ ARC_STAT arc_eom(ARC_MESSAGE *);
 **  	prepended to the message in the presented order.
 */
 
-ARC_STAT arc_getseal(ARC_MESSAGE *, ARC_HDRFIELD **, char *, char *, char *,
-                     u_char *, size_t, u_char *);
+extern ARC_STAT arc_getseal (ARC_MESSAGE *, ARC_HDRFIELD **, char *, char *,
+			     char *, u_char *, size_t, u_char *);
 
 /*
 **  ARC_HDR_NAME -- extract name from an ARC_HDRFIELD
@@ -476,7 +476,7 @@ ARC_STAT arc_getseal(ARC_MESSAGE *, ARC_HDRFIELD **, char *, char *, char *,
 **  	Header field name stored in the object.
 */
 
-u_char *arc_hdr_name(ARC_HDRFIELD *, size_t *);
+extern u_char *arc_hdr_name (ARC_HDRFIELD *, size_t *);
 
 /*
 **  ARC_HDR_VALUE -- extract value from an ARC_HDRFIELD
@@ -488,7 +488,7 @@ u_char *arc_hdr_name(ARC_HDRFIELD *, size_t *);
 **  	Header field value stored in the object.
 */
 
-u_char *arc_hdr_value(ARC_HDRFIELD *);
+extern u_char *arc_hdr_value (ARC_HDRFIELD *);
 
 /*
 **  ARC_HDR_NEXT -- return pointer to next ARC_HDRFIELD
@@ -500,7 +500,7 @@ u_char *arc_hdr_value(ARC_HDRFIELD *);
 **  	Pointer to the next ARC_HDRFIELD in the sequence.
 */
 
-ARC_HDRFIELD *arc_hdr_next(ARC_HDRFIELD *hdr);
+extern ARC_HDRFIELD *arc_hdr_next (ARC_HDRFIELD *hdr);
 
 /*
 **  ARC_SSL_VERSION -- report the version of the crypto library against which
@@ -513,6 +513,6 @@ ARC_HDRFIELD *arc_hdr_next(ARC_HDRFIELD *hdr);
 **  	SSL library version, expressed as a uint64_t.
 */
 
-uint64_t arc_ssl_version(void);
+extern uint64_t arc_ssl_version (void);
 
 #endif /* _ARC_H_ */

--- a/m4/ltversion.m4
+++ b/m4/ltversion.m4
@@ -9,15 +9,15 @@
 
 # @configure_input@
 
-# serial 3337 ltversion.m4
+# serial 3293 ltversion.m4
 # This file is part of GNU Libtool
 
-m4_define([LT_PACKAGE_VERSION], [2.4.2])
-m4_define([LT_PACKAGE_REVISION], [1.3337])
+m4_define([LT_PACKAGE_VERSION], [2.4])
+m4_define([LT_PACKAGE_REVISION], [1.3293])
 
 AC_DEFUN([LTVERSION_VERSION],
-[macro_version='2.4.2'
-macro_revision='1.3337'
+[macro_version='2.4'
+macro_revision='1.3293'
 _LT_DECL(, macro_version, 0, [Which release of libtool.m4 was used?])
 _LT_DECL(, macro_revision, 0)
 ])

--- a/m4/ltversion.m4
+++ b/m4/ltversion.m4
@@ -9,15 +9,15 @@
 
 # @configure_input@
 
-# serial 3293 ltversion.m4
+# serial 3337 ltversion.m4
 # This file is part of GNU Libtool
 
-m4_define([LT_PACKAGE_VERSION], [2.4])
-m4_define([LT_PACKAGE_REVISION], [1.3293])
+m4_define([LT_PACKAGE_VERSION], [2.4.2])
+m4_define([LT_PACKAGE_REVISION], [1.3337])
 
 AC_DEFUN([LTVERSION_VERSION],
-[macro_version='2.4'
-macro_revision='1.3293'
+[macro_version='2.4.2'
+macro_revision='1.3337'
 _LT_DECL(, macro_version, 0, [Which release of libtool.m4 was used?])
 _LT_DECL(, macro_revision, 0)
 ])

--- a/openarc/Makefile.am
+++ b/openarc/Makefile.am
@@ -6,7 +6,7 @@ AM_CFLAGS = -g
 endif
 
 if BUILD_FILTER
-dist_doc_DATA = openarc.conf.sample
+dist_doc_DATA = openarc.conf.simple
 
 man_MANS = openarc.conf.5 openarc.8
 

--- a/openarc/openarc.c
+++ b/openarc/openarc.c
@@ -281,7 +281,7 @@ char myhostname[MAXHOSTNAMELEN + 1];		/* local host's name */
 **  	An sfsistat.
 */
 
-sfsistat 
+sfsistat
 smfi_insheader(SMFICTX *ctx, int idx, char *hname, char *hvalue)
 {
 	assert(ctx != NULL);
@@ -959,7 +959,7 @@ arcf_securefile(const char *path, ino_t *ino, uid_t myuid, char *err,
 			return status;
 
 		if (partial[1] != '\0')
-			strlcat(partial, "/", sizeof partial); 
+			strlcat(partial, "/", sizeof partial);
 	}
 
 	return 1;
@@ -1015,7 +1015,7 @@ arcf_securefile(const char *path, ino_t *ino, uid_t myuid, char *err,
 
 		pthread_mutex_unlock(&pwdb_lock);
 	}
-		
+
 	/* guess we're okay... */
 	*ino = s.st_ino;
 	return 1;
@@ -1340,7 +1340,7 @@ arcf_config_load(struct config *data, struct arcf_config *conf,
 		(void) config_get(data, "AuthservID", &str, sizeof str);
 	if (str == NULL || strcmp(str, "HOSTNAME") == 0)
 		conf->conf_authservid = strdup(myhostname);
-	else	
+	else
 		conf->conf_authservid = strdup(str);
 
 	if (data != NULL)
@@ -1608,7 +1608,7 @@ arcf_config_load(struct config *data, struct arcf_config *conf,
 
 				saveerrno = errno;
 
-				syslog(LOG_ERR, "malloc(): %s", 
+				syslog(LOG_ERR, "malloc(): %s",
 				       strerror(errno));
 
 				errno = saveerrno;
@@ -2059,7 +2059,7 @@ arcf_cleanup(SMFICTX *ctx)
 			while (cur != NULL)
 			{
 				next = cur->se_next;
-	
+
 				free(cur);
 
 				cur = next;
@@ -2844,7 +2844,7 @@ mlfi_header(SMFICTX *ctx, char *headerf, char *headerv)
 		**  feed to the canonicalization algorithms the headers
 		**  exactly as the MTA will modify them, so verification
 		**  should still work.
-		**  
+		**
 		**  This is based on experimentation and on reading
 		**  sendmail/headers.c, and may require more tweaking before
 		**  it's precisely right.  There are other munges the
@@ -3326,7 +3326,7 @@ mlfi_eom(SMFICTX *ctx)
 		size_t len;
 		u_char *hfptr;
 		u_char hfname[BUFRSZ + 1];
-	
+
 		hfptr = arc_hdr_name(sealhdr, &len);
 		memset(hfname, '\0', sizeof hfname);
 		strncpy(hfname, hfptr, len);


### PR DESCRIPTION
The chain validation algorithm had some issues, which I believe I've fixed.  They're twofold.  The first is simple incorrect functionality.  The second is that it was retuning error codes other than ARC_STATUS_OK, which caused the header generation to abort.  This should never be the case.  In case of an invalid configuration or non-signature failure mode, we shouldn't hardfail, we should continue to generate the ARC Set.  It's debatable whether this is the correct approach however.

Also, there was a bug with AS validation.