### PR TITLE
Fixing AR parsing issues

### DIFF
--- a/libopenarc/arc-canon.c
+++ b/libopenarc/arc-canon.c
@@ -1207,9 +1207,6 @@ arc_canon_runheaders_seal(ARC_MESSAGE *msg)
 			return status;
 	}
 
-	/* now finalize the main one */
-	arc_canon_finalize(msg->arc_sealcanon);
-
 	return ARC_STAT_OK;
 }
 

--- a/m4/ltversion.m4
+++ b/m4/ltversion.m4
@@ -9,15 +9,15 @@
 
 # @configure_input@
 
-# serial 3293 ltversion.m4
+# serial 3337 ltversion.m4
 # This file is part of GNU Libtool
 
-m4_define([LT_PACKAGE_VERSION], [2.4])
-m4_define([LT_PACKAGE_REVISION], [1.3293])
+m4_define([LT_PACKAGE_VERSION], [2.4.2])
+m4_define([LT_PACKAGE_REVISION], [1.3337])
 
 AC_DEFUN([LTVERSION_VERSION],
-[macro_version='2.4'
-macro_revision='1.3293'
+[macro_version='2.4.2'
+macro_revision='1.3337'
 _LT_DECL(, macro_version, 0, [Which release of libtool.m4 was used?])
 _LT_DECL(, macro_revision, 0)
 ])

--- a/openarc/openarc-ar.c
+++ b/openarc/openarc-ar.c
@@ -376,7 +376,7 @@ ares_dedup(struct authres *ar, int n)
 **  	hdr -- NULL-terminated contents of an Authentication-Results:
 **  	       header field
 **  	ar -- a pointer to a (struct authres) loaded by values after parsing
-**  
+**
 **  Return value:
 **  	0 on success, -1 on failure.
 */
@@ -410,7 +410,12 @@ ares_parse(u_char *hdr, struct authres *ar)
 	for (c = 0; c < ntoks; c++)
 	{
 		if (tokens[c][0] == '(')		/* comment */
+		{
+			strlcpy((char *) ar->ares_result[n - 1].result_comment,
+			        (char *) tokens[c],
+			        sizeof ar->ares_result[n - 1].result_comment);
 			continue;
+		}
 
 		switch (state)
 		{
@@ -511,6 +516,7 @@ ares_parse(u_char *hdr, struct authres *ar)
 		  case 5:				/* result */
 			ar->ares_result[n - 1].result_result = ares_convert(aresults,
 			                                                    (char *) tokens[c]);
+			ar->ares_result[n - 1].result_comment[0] = '\0';
 			prevstate = state;
 			state = 6;
 
@@ -674,7 +680,7 @@ ares_parse(u_char *hdr, struct authres *ar)
 **
 **  Parameters:
 **  	method -- method to convert
-** 
+**
 **  Return value:
 **  	String matching the provided method, or NULL.
 */
@@ -690,7 +696,7 @@ ares_getmethod(ares_method_t method)
 **
 **  Parameters:
 **  	result -- result to convert
-** 
+**
 **  Return value:
 **  	String matching the provided result, or NULL.
 */
@@ -706,7 +712,7 @@ ares_getresult(ares_result_t result)
 **
 **  Parameters:
 **  	ptype -- ptype to convert
-** 
+**
 **  Return value:
 **  	String matching the provided ptype, or NULL.
 */

--- a/openarc/openarc-ar.h
+++ b/openarc/openarc-ar.h
@@ -74,6 +74,7 @@ struct result
 	ares_result_t	result_result;
 	ares_ptype_t	result_ptype[MAXPROPS];
 	unsigned char	result_reason[MAXAVALUE + 1];
+	unsigned char	result_comment[MAXAVALUE + 1];
 	unsigned char	result_property[MAXPROPS][MAXAVALUE + 1];
 	unsigned char	result_value[MAXPROPS][MAXAVALUE + 1];
 };
@@ -95,7 +96,7 @@ struct authres
 **  	hdr -- NULL-terminated contents of an Authentication-Results:
 **  	       header field
 **  	ar -- a pointer to a (struct authres) loaded by values after parsing
-**  
+**
 **  Return value:
 **  	0 on success, -1 on failure.
 */

--- a/openarc/openarc.c
+++ b/openarc/openarc.c
@@ -3265,15 +3265,19 @@ mlfi_eom(SMFICTX *ctx)
 			int m;
 			int n;
 
-			if (arcf_dstring_len(afc->mctx_tmpstr) > 0)
-				arcf_dstring_cat(afc->mctx_tmpstr, "; ");
-
 			for (n = 0; n < ar.ares_count; n++)
 			{
 				arcf_dstring_printf(afc->mctx_tmpstr,
 				                    "%s=%s",
 				                    ares_getmethod(ar.ares_result[n].result_method),
 				                    ares_getresult(ar.ares_result[n].result_result));
+
+				if(ar.ares_result[n].result_comment[0] != '\0')
+				{
+					arcf_dstring_printf(afc->mctx_tmpstr,
+					                    " %s",
+					                    ar.ares_result[n].result_comment);
+				}
 
 				for (m = 0;
 				     m < ar.ares_result[n].result_props;
@@ -3292,6 +3296,9 @@ mlfi_eom(SMFICTX *ctx)
 					                    " reason=\"%s\"",
 					                    ar.ares_result[0].result_reason);
 				}
+
+				if (n != ar.ares_count - 1)
+					arcf_dstring_cat(afc->mctx_tmpstr, "; ");
 			}
 		}
 	}


### PR DESCRIPTION
Three basic fixes here.  One, I've added support for comments in the AR parsing pipeline, although I'm not sure that my implementation is ideal.  Happy to take suggestions.  

Second, I've fixed a bug wrt AR parsing, where the different tokens were not being recombined correctly to the final result.  This messed up AAR generation & therefore broke all AS signatures.

One final issue where arc_canon_finalize(msg->arc_sealcanon); was being called inappropriately.  It doesn't need to happen in arc_canon_runheaders_seal, for the new seal canonicalization, as its called after the final AS is added to the canon in arc_canon_signature