### PR TITLE
initscript: use -c $CONFIG

### DIFF
--- a/contrib/init/generic/openarc
+++ b/contrib/init/generic/openarc
@@ -143,7 +143,7 @@ fi
 
 od_start() {
 	echo -n "Starting OpenARC Milter: "
-	od_daemon $DAEMON -x $CONFIG $ARGS
+	od_daemon $DAEMON -c $CONFIG $ARGS
 	if [ $? -eq 0 ]; then
 		log_success_msg $NAME
 		if [ -d /var/lock/subsys ]; then


### PR DESCRIPTION
The initscript was passing argument -x $CONFIG, though -x is not
an argument to pass the config file name, -c is.  Fix the initscript
to use -c instead of -x.