### PR TITLE
Add support for OpenSSL 1.1.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -632,7 +632,7 @@ then
 	AC_SEARCH_LIBS([ERR_peek_error], [crypto], ,
 	               AC_MSG_ERROR([libcrypto not found]))
 
-	AC_SEARCH_LIBS([SSL_library_init], [ssl], ,
+	AC_SEARCH_LIBS([SSL_new], [ssl], ,
 		[
 			if test x"$enable_shared" = x"yes"
 			then
@@ -644,11 +644,11 @@ then
 				              openarc to use.])
 			fi
 
-			# avoid caching issue - last result of SSL_library_init
+			# avoid caching issue - last result of SSL_new
 			# shouldn't be cached for this next check
-			unset ac_cv_search_SSL_library_init
+			unset ac_cv_search_SSL_new
 			LIBCRYPTO_LIBS="$LIBCRYPTO_LIBS -ldl"
-			AC_SEARCH_LIBS([SSL_library_init], [ssl], ,
+			AC_SEARCH_LIBS([SSL_new], [ssl], ,
 			               AC_MSG_ERROR([libssl not found]), [-ldl])
 		]
 	)

--- a/openarc/openarc-crypto.c
+++ b/openarc/openarc-crypto.c
@@ -4,6 +4,10 @@
 **
 */
 
+#include <openssl/opensslv.h>
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+
 #include "build-config.h"
 
 /* system includes */
@@ -310,3 +314,5 @@ arcf_crypto_free(void)
 		crypto_init_done = FALSE;
 	}
 }
+
+#endif /* OpenSSL < 1.1.0 */

--- a/openarc/openarc.c
+++ b/openarc/openarc.c
@@ -3674,7 +3674,12 @@ main(int argc, char **argv)
 			printf("%s: %s v%s\n", progname, ARCF_PRODUCT,
 			       VERSION);
 			printf("\tCompiled with %s\n",
-			       SSLeay_version(SSLEAY_VERSION));
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+			       SSLeay_version(SSLEAY_VERSION)
+#else
+			       OpenSSL_version(OPENSSL_VERSION)
+#endif /* OpenSSL < 1.1.0 */
+			       );
 			printf("\tSMFI_VERSION 0x%x\n", SMFI_VERSION);
 #ifdef HAVE_SMFI_VERSION
 			(void) smfi_version(&mvmajor, &mvminor, &mvrelease);
@@ -4537,6 +4542,7 @@ main(int argc, char **argv)
 	}
 #endif /* HAVE_SMFI_OPENSOCKET */
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
 	/* initialize libcrypto mutexes */
 	if (!curconf->conf_disablecryptoinit)
 	{
@@ -4548,6 +4554,7 @@ main(int argc, char **argv)
 			        progname, strerror(status));
 		}
 	}
+#endif /* OpenSSL < 1.1.0 */
 
 	pthread_mutex_init(&conf_lock, NULL);
 	pthread_mutex_init(&pwdb_lock, NULL);
@@ -4623,7 +4630,9 @@ main(int argc, char **argv)
 	if (!autorestart && pidfile != NULL)
 		(void) unlink(pidfile);
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
 	arcf_crypto_free();
+#endif /* OpenSSL < 1.1.0 */
 
 	arcf_config_free(curconf);
 


### PR DESCRIPTION
This mainly entails not doing things; 1.1.0 removes the need for manual init/deinit and implements lock callbacks internally instead of making the calling program set them up.

The preprocessor conditionals are a little ugly because LibreSSL forked from an old API but claims to be OpenSSL 2.0.

I'm not 100% about the autoconf changes; they work, but `SSL_new` might not be the most appropriate thing to check for.