### PR TITLE
do not use CR to fold a long header line

### DIFF
--- a/libopenarc/arc.c
+++ b/libopenarc/arc.c
@@ -606,7 +606,7 @@ arc_getamshdr_d(ARC_MESSAGE *msg, size_t initial, u_char **buf, size_t *buflen,
 			{
 				forcewrap = FALSE;
 				arc_dstring_catn(msg->arc_hdrbuf,
-				                  (u_char *) "\r\n\t", 3);
+				                  (u_char *) "\n\t", 2);
 				len = 8;
 
 				if (strcmp(which, "h") == 0)
@@ -636,8 +636,8 @@ arc_getamshdr_d(ARC_MESSAGE *msg, size_t initial, u_char **buf, size_t *buflen,
 							                 ':');
 							len += 1;
 							arc_dstring_catn(msg->arc_hdrbuf,
-							                 (u_char *) "\r\n\t ",
-							                 4);
+							                 (u_char *) "\n\t ",
+							                 3);
 							len = 9;
 							arc_dstring_catn(msg->arc_hdrbuf,
 							                 (u_char *) tmp,
@@ -688,8 +688,8 @@ arc_getamshdr_d(ARC_MESSAGE *msg, size_t initial, u_char **buf, size_t *buflen,
 						if (msg->arc_margin - len == 0)
 						{
 							arc_dstring_catn(msg->arc_hdrbuf,
-							                  (u_char *) "\r\n\t ",
-							                  4);
+							                  (u_char *) "\n\t ",
+							                  3);
 							len = 9;
 						}
 


### PR DESCRIPTION
In function arc_getamshdr_d() in file libopenarc/arc.c the long AMS/AS header will be chopped into short pieces, separated by "\r\n\t". This will insert CR ("\r") at the line ends of these headers and break some MUAs (e.g. K9 Mail on Android). The documentation of smfi_addheader() and smfi_insheader() says:

> To make a multi-line header, insert a line feed (ASCII 0x0a, or \n in C) followed by at least one whitespace character such as a space (ASCII 0x20) or tab (ASCII 0x09, or \t in C). The line feed should NOT be preceded by a carriage return (ASCII 0x0d); the MTA will add this automatically.