### PR TITLE
add leading white space to A-R header content if MTA negotiated SMFIP_HDR_LEADSPC

### DIFF
--- a/openarc/openarc.c
+++ b/openarc/openarc.c
@@ -3351,11 +3351,12 @@ mlfi_eom(SMFICTX *ctx)
 	*/
 
 	arcf_dstring_blank(afc->mctx_tmpstr);
-	arcf_dstring_printf(afc->mctx_tmpstr, "%s; arc=%s header.d=%s",
+	arcf_dstring_printf(afc->mctx_tmpstr, "%s%s; arc=%s header.d=%s",
+	                    cc->cctx_noleadspc ? " " : "",
 	                    conf->conf_authservid,
 	                    arc_chain_str(afc->mctx_arcmsg),
 	                    arc_get_domain(afc->mctx_arcmsg));
-	if (arcf_addheader(ctx, AUTHRESULTSHDR,
+	if (arcf_insheader(ctx, 1, AUTHRESULTSHDR,
 	                   arcf_dstring_get(afc->mctx_tmpstr)) != MI_SUCCESS)
 	{
 		if (conf->conf_dolog)


### PR DESCRIPTION
The A-R header added by OpenARC misses a space after the colon that delimits the header name from the content, if the milter negotiated the option `SMFIP_HDR_LEADSPC` with the MTA. This will fix it.
I also changed `smfi_addheader()` to `smfi_insheader()` as the A-R header usually preceedes the Received header (at least OpenDKIM and OpenDMARC handle it this way).