### PR TITLE
Don't defer message if A-R header cannot be parsed

### DIFF
--- a/openarc/openarc-ar.c
+++ b/openarc/openarc-ar.c
@@ -482,7 +482,7 @@ ares_parse(u_char *hdr, struct authres *ar)
 
 			break;
 
-		  case 3:				/* method */
+		  case 3:				/* method/none */
 			if (n == 0 || !ares_dedup(ar, n))
 				n++;
 
@@ -490,6 +490,14 @@ ares_parse(u_char *hdr, struct authres *ar)
 				return 0;
 
 			r = 0;
+
+			if (strcasecmp((char *) tokens[c], "none") == 0)
+			{
+				if (n > 0)
+					n--;
+
+				continue;
+			}
 
 			ar->ares_result[n - 1].result_method = ares_convert(methods,
 			                                                    (char *) tokens[c]);

--- a/openarc/openarc-ar.c
+++ b/openarc/openarc-ar.c
@@ -502,7 +502,7 @@ ares_parse(u_char *hdr, struct authres *ar)
 					n--;
 
 				prevstate = state;
-				state = 2;
+				state = 14;
 
 				continue;
 			}
@@ -667,6 +667,11 @@ ares_parse(u_char *hdr, struct authres *ar)
 			state = 9;
 
 			break;
+
+		  case 14:				/* only reached in case of a malformed A-R */
+			return -1;
+
+			break;				/* not reached, just to make some lint-like sw happy */
 		}
 	}
 

--- a/openarc/openarc-ar.c
+++ b/openarc/openarc-ar.c
@@ -501,6 +501,9 @@ ares_parse(u_char *hdr, struct authres *ar)
 				if (n > 0)
 					n--;
 
+				prevstate = state;
+				state = 2;
+
 				continue;
 			}
 

--- a/openarc/openarc.c
+++ b/openarc/openarc.c
@@ -3253,7 +3253,7 @@ mlfi_eom(SMFICTX *ctx)
 			if (conf->conf_dolog)
 			{
 				syslog(LOG_WARNING,
-				       "%s: can't parse %s",
+				       "%s: can't parse %s; ignoring",
 				       afc->mctx_jobid, AR_HEADER_NAME);
 			}
 

--- a/openarc/openarc.c
+++ b/openarc/openarc.c
@@ -3257,7 +3257,7 @@ mlfi_eom(SMFICTX *ctx)
 				       afc->mctx_jobid, AR_HEADER_NAME);
 			}
 
-			return SMFIS_TEMPFAIL;
+			continue;
 		}
 
 		if (strcasecmp(conf->conf_authservid, ar.ares_host) == 0)


### PR DESCRIPTION
Don't defer a message if a A-R header cannot be parsed - just ignore it. 
Addtionally try to correctly parse a valid A-R header with only 'none' in it.

