### PR TITLE
fix empty b= tag

### DIFF
--- a/libopenarc/arc.c
+++ b/libopenarc/arc.c
@@ -676,11 +676,7 @@ arc_getamshdr_d(ARC_MESSAGE *msg, size_t initial, u_char **buf, size_t *buflen,
 
 					len += offset;
 
-					arc_dstring_cat1(msg->arc_hdrbuf,
-					                 *(pv + offset));
-					len++;
-
-					x = pv + offset + 1;
+					x = pv + offset;
 					y = pv + pvlen;
 
 					while (x < y)


### PR DESCRIPTION
**Symptom:** The b tag was empty if it was wrapped onto a new line and was the first tag in this line.
**Cause:** The logic behind the wrapping split a tag into tag name and value, appended the name to the destination string, a '=' and then assumed that the value would contain at least one character - which the b tag at this stage does not have. Therefore a '\0' was appended and the length increased by one - eventhough appending a '\0' to a string does *not* increase the length of that string. Later on, the signature was appended behind that '\0' and therefore invisible.
**Fix:** Removed the code that appended the first character and let the following loop handle all characters of the tag value - it does it right.