### PR TITLE
added missing include for strlcat()

### DIFF
--- a/libopenarc/arc-util.c
+++ b/libopenarc/arc-util.c
@@ -31,6 +31,11 @@
 #include "arc-types.h"
 #include "arc-util.h"
 
+/* libbsd if found */
+#ifdef USE_BSD_H
+# include <bsd/string.h>
+#endif /* USE_BSD_H */
+
 #if defined(__RES) && (__RES >= 19940415)
 # define RES_UNC_T		char *
 #else /* __RES && __RES >= 19940415 */


### PR DESCRIPTION
The following compiler warning is fixed by this pull request:
```
arc-util.c: In function 'arc_hdrlist':
arc-util.c:557:4: warning: implicit declaration of function 'strlcat' [-Wimplicit-function-declaration]
    len = strlcat((char *) buf, "|", buflen);
```

Thanks to Andreas Schulze for this one.