### PR TITLE
Split signing and verification to enable SHA-1 handling/canonicalization

### DIFF
--- a/libopenarc/arc-canon.c
+++ b/libopenarc/arc-canon.c
@@ -2057,8 +2057,8 @@ arc_canon_gethashes(ARC_MESSAGE *msg, void **hh, size_t *hhlen,
 	size_t hdlen;
 	size_t bdlen;
 
-	hdc = msg->arc_hdrcanon;
-	bdc = msg->arc_bodycanon;
+	hdc = msg->arc_valid_hdrcanon;
+	bdc = msg->arc_valid_bodycanon;
 
 	status = arc_canon_getfinal(hdc, &hd, &hdlen);
 	if (status != ARC_STAT_OK)

--- a/libopenarc/arc-types.h
+++ b/libopenarc/arc-types.h
@@ -179,8 +179,10 @@ struct arc_msghandle
 	struct arc_dstring *	arc_hdrbuf;
 	struct arc_canon *	arc_sealcanon;
 	struct arc_canon **	arc_sealcanons;
-	struct arc_canon *	arc_hdrcanon;
-	struct arc_canon *	arc_bodycanon;
+	struct arc_canon *	arc_valid_hdrcanon;
+	struct arc_canon *	arc_sign_hdrcanon;
+	struct arc_canon *	arc_valid_bodycanon;
+	struct arc_canon *	arc_sign_bodycanon;
 	struct arc_canon *	arc_canonhead;
 	struct arc_canon *	arc_canontail;
 	struct arc_hdrfield *	arc_hhead;

--- a/libopenarc/arc.c
+++ b/libopenarc/arc.c
@@ -416,7 +416,7 @@ arc_genamshdr(ARC_MESSAGE *msg, struct arc_dstring *dstr, char *delim,
 		if (status != ARC_STAT_OK)
 			return 0;
 
-		status = arc_canon_getfinal(msg->arc_bodycanon,
+		status = arc_canon_getfinal(msg->arc_sign_bodycanon,
 		                            &hash, &hashlen);
 		if (status != ARC_STAT_OK)
 		{
@@ -432,7 +432,7 @@ arc_genamshdr(ARC_MESSAGE *msg, struct arc_dstring *dstr, char *delim,
 		if (msg->arc_partial)
 		{
 			arc_dstring_printf(dstr, ";%sl=%lu", delim,
-		                   	   (u_long) msg->arc_bodycanon->canon_wrote);
+					   (u_long) msg->arc_sign_bodycanon->canon_wrote);
 		}
 
 		/* h= */
@@ -2510,42 +2510,42 @@ arc_eoh(ARC_MESSAGE *msg)
 	**  Request specific canonicalizations we want to run.
 	*/
 
-	/* header */
+	/* headers, validation */
 	h = NULL;
 	htag = NULL;
 	if (nsets > 0)
 	{
 		h = msg->arc_sets[nsets - 1].arcset_ams;
 		htag = arc_param_get(h->hdr_data, "h");
+
+		if (strcmp(arc_param_get(h->hdr_data, "a"), "rsa-sha1") == 0)
+			hashtype = ARC_HASHTYPE_SHA1;
+		else
+			hashtype = ARC_HASHTYPE_SHA256;
+
+		status = arc_add_canon(msg, ARC_CANONTYPE_HEADER, msg->arc_canonhdr,
+		                       hashtype, htag, h, (ssize_t) -1,
+		                       &msg->arc_valid_hdrcanon);
+		if (status != ARC_STAT_OK)
+		{
+			arc_error(msg,
+			          "failed to initialize header canonicalization object");
+			return status;
+		}
+
+		/* body, validation */
+		status = arc_add_canon(msg, ARC_CANONTYPE_BODY, msg->arc_canonbody,
+		                       hashtype, NULL, NULL, (ssize_t) -1,
+		                       &msg->arc_valid_bodycanon);
+		if (status != ARC_STAT_OK)
+		{
+			arc_error(msg,
+			          "failed to initialize body canonicalization object");
+			return status;
+		}
 	}
 
-	if (msg->arc_signalg == ARC_SIGN_RSASHA1)
-		hashtype = ARC_HASHTYPE_SHA1;
-	else
-		hashtype = ARC_HASHTYPE_SHA256;
-
-	status = arc_add_canon(msg, ARC_CANONTYPE_HEADER, msg->arc_canonhdr,
-	                       hashtype, htag, h, (ssize_t) -1,
-	                       &msg->arc_hdrcanon);
-	if (status != ARC_STAT_OK)
-	{
-		arc_error(msg,
-			  "failed to initialize header canonicalization object");
-		return status;
-	}
-
-	/* body */
-	status = arc_add_canon(msg, ARC_CANONTYPE_BODY, msg->arc_canonbody,
-	                       hashtype, NULL, NULL, (ssize_t) -1,
-	                       &msg->arc_bodycanon);
-	if (status != ARC_STAT_OK)
-	{
-		arc_error(msg,
-			  "failed to initialize body canonicalization object");
-		return status;
-	}
-
-	/* sets already in the chain */
+	/* sets already in the chain, validation */
 	if (nsets > 0)
 	{
 		msg->arc_sealcanons = malloc(nsets * sizeof(ARC_CANON *));
@@ -2560,8 +2560,8 @@ arc_eoh(ARC_MESSAGE *msg)
 		{
 			h = msg->arc_sets[n].arcset_as;
 
-			if (strcmp(arc_param_get(h->hdr_data, "a"),
-			           "rsa-sha1") == 0)
+			int hashtype;
+			if (strcmp(arc_param_get(h->hdr_data, "a"), "rsa-sha1") == 0)
 				hashtype = ARC_HASHTYPE_SHA1;
 			else
 				hashtype = ARC_HASHTYPE_SHA256;
@@ -2577,13 +2577,24 @@ arc_eoh(ARC_MESSAGE *msg)
 			if (status != ARC_STAT_OK)
 			{
 				arc_error(msg,
-			          	"failed to initialize seal canonicalization object");
+					"failed to initialize seal canonicalization object");
 				return status;
 			}
 		}
 	}
 
-	/* all sets, for the next chain */
+	/* headers, signing */
+	status = arc_add_canon(msg, ARC_CANONTYPE_HEADER, msg->arc_canonhdr,
+	                       msg->arc_signalg, NULL, NULL, (ssize_t) -1,
+	                       &msg->arc_sign_hdrcanon);
+	if (status != ARC_STAT_OK)
+	{
+		arc_error(msg,
+		          "failed to initialize header canonicalization object");
+		return status;
+	}
+
+	/* all sets, for the next chain, signing */
 	status = arc_add_canon(msg,
 	                       ARC_CANONTYPE_SEAL,
 	                       ARC_CANON_RELAXED,
@@ -2595,7 +2606,18 @@ arc_eoh(ARC_MESSAGE *msg)
 	if (status != ARC_STAT_OK)
 	{
 		arc_error(msg,
-	          	"failed to initialize seal canonicalization object");
+			"failed to initialize seal canonicalization object");
+		return status;
+	}
+
+	/* body, signing */
+	status = arc_add_canon(msg, ARC_CANONTYPE_BODY, msg->arc_canonbody,
+	                       msg->arc_signalg, NULL, NULL, (ssize_t) -1,
+	                       &msg->arc_sign_bodycanon);
+	if (status != ARC_STAT_OK)
+	{
+		arc_error(msg,
+		          "failed to initialize body canonicalization object");
 		return status;
 	}
 
@@ -2931,7 +2953,7 @@ arc_getseal(ARC_MESSAGE *msg, ARC_HDRFIELD **seal, char *authservid,
 		return ARC_STAT_INTERNAL;
 	}
 
-	status = arc_canon_getfinal(msg->arc_hdrcanon, &digest, &diglen);
+	status = arc_canon_getfinal(msg->arc_sign_hdrcanon, &digest, &diglen);
 	if (status != ARC_STAT_OK)
 	{
 		arc_error(msg, "arc_canon_getfinal() failed");


### PR DESCRIPTION
Split the verification and signing.
Adds SHA-1 support.
Separate canonicalization for verification/signing coming in a future PR. 