### PR TITLE
New option to select signing and/or verifying

### DIFF
--- a/openarc/openarc-config.h
+++ b/openarc/openarc-config.h
@@ -37,6 +37,7 @@ struct configdef arcf_config[] =
 	{ "KeyFile",			CONFIG_TYPE_STRING,	TRUE },
 	{ "MaximumHeaders",		CONFIG_TYPE_INTEGER,	FALSE },
 	{ "MilterDebug",		CONFIG_TYPE_INTEGER,	FALSE },
+	{ "Mode",			CONFIG_TYPE_STRING,	FALSE },
 	{ "PeerList",			CONFIG_TYPE_STRING,	FALSE },
 	{ "PidFile",			CONFIG_TYPE_STRING,	FALSE },
 	{ "Selector",			CONFIG_TYPE_STRING,	TRUE },

--- a/openarc/openarc.8.in
+++ b/openarc/openarc.8.in
@@ -4,6 +4,7 @@
 \- ARC signing and verifying filter for MTAs
 .SH SYNOPSIS
 .B openarc
+[\-b modes]
 [\-c configfile]
 [\-f]
 [\-n]
@@ -27,6 +28,17 @@ interface, originally distributed as part of version 8.11 of
 to provide ARC signing and/or verifying service for mail transiting
 a milter-aware MTA.
 .SH OPTIONS
+.TP
+.I \-b modes
+Selects operating modes.
+.I modes
+is a concatenation of characters that indicate which mode(s) of operation
+are desired.  Valid modes are
+.I s
+(signer) and
+.I v
+(verifier).  The default is
+.I sv.
 .TP
 .I \-c configfile
 Read the named configuration file.  See the

--- a/openarc/openarc.conf.5.in
+++ b/openarc/openarc.conf.5.in
@@ -116,6 +116,12 @@ Sets the debug level to be requested from the milter library.  The
 default is 0.
 
 .TP
+.I Mode (string)
+Selects  operating modes. The string is a concatenation of characters that
+indicate which mode(s) of operation are desired. Valid modes are s (signer)
+and v (verifier). The default is sv.
+
+.TP
 .I OversignHeaders (string)
 Specifies a comma-separated list of header field names that should be
 included in all signature header lists (the "h=" tag) once more than the

--- a/openarc/openarc.conf.sample
+++ b/openarc/openarc.conf.sample
@@ -139,6 +139,14 @@ KeyFile			/var/db/dkim/example.private
 
 # Minimum		n
 
+##  Mode [sv]
+##      default sv
+##
+##  Indicates which mode(s) of operation should be provided.  "s" means
+##  "sign", "v" means "verify".
+
+# Mode                  sv
+
 ##  OversignHeaders (string)
 ##  	default (none)
 ##


### PR DESCRIPTION
Copied the `Mode` option from OpenDKIM. Cheap implementation that works by just only adding the relevant headers if `s` or `v` is specified. All calculations of signatures are still done.
This pull request is not really meant to be included into the master branch but may help others to try out different operation modes in real life scenarios.