### PR TITLE
Support for Simple Canonicalization

### DIFF
--- a/libopenarc/arc-canon.c
+++ b/libopenarc/arc-canon.c
@@ -30,6 +30,7 @@
 #include "arc-types.h"
 #include "arc-canon.h"
 #include "arc-util.h"
+#include "arc-tables.h"
 
 /* libbsd if found */
 #ifdef USE_BSD_H
@@ -1453,7 +1454,6 @@ arc_canon_runheaders(ARC_MESSAGE *msg)
 		tmphdr.hdr_flags = 0;
 		tmphdr.hdr_next = NULL;
 
-		arc_lowerhdr(tmphdr.hdr_text);
 		(void) arc_canon_header(msg, cur, &tmphdr, FALSE);
 		arc_canon_buffer(cur, NULL, 0);
 
@@ -2100,6 +2100,44 @@ arc_canon_add_to_seal(ARC_MESSAGE *msg)
 		if (status != ARC_STAT_OK)
 			return status;
 	}
+
+	return ARC_STAT_OK;
+}
+
+/*
+**  ARC_PARSE_CANON_T -- parse a c= tag
+**
+**  Parameters:
+**    tag        -- c=
+**    hdr_canon  -- the header canon output
+**    body_canon -- the body canon output
+**
+**  Return value:
+**    ARC_STAT_OK -- successful completion
+*/
+
+ARC_STAT
+arc_parse_canon_t(unsigned char *tag, arc_canon_t *hdr_canon, arc_canon_t *body_canon)
+{
+	char *token = NULL;
+	int code = 0;
+	char *last = NULL;
+
+	token = strtok_r(tag, "/", &last);
+	code = arc_name_to_code(canonicalizations, token);
+
+	if (code == -1)
+		return ARC_STAT_INVALID;
+
+	*hdr_canon = (arc_canon_t) code;
+
+	token = strtok_r(NULL, "/", &last);
+	code = arc_name_to_code(canonicalizations, token);
+
+	if (code == -1)
+		return ARC_STAT_INVALID;
+
+	*body_canon = (arc_canon_t) code;
 
 	return ARC_STAT_OK;
 }

--- a/libopenarc/arc-canon.c
+++ b/libopenarc/arc-canon.c
@@ -2123,6 +2123,10 @@ arc_parse_canon_t(unsigned char *tag, arc_canon_t *hdr_canon, arc_canon_t *body_
 	int code = 0;
 	char *last = NULL;
 
+	assert(tag != NULL)
+	assert(hdr_canon != NULL)
+	assert(body_canon != NULL)
+
 	token = strtok_r(tag, "/", &last);
 	code = arc_name_to_code(canonicalizations, token);
 

--- a/libopenarc/arc-canon.c
+++ b/libopenarc/arc-canon.c
@@ -2123,9 +2123,9 @@ arc_parse_canon_t(unsigned char *tag, arc_canon_t *hdr_canon, arc_canon_t *body_
 	int code = 0;
 	char *last = NULL;
 
-	assert(tag != NULL)
-	assert(hdr_canon != NULL)
-	assert(body_canon != NULL)
+	assert(tag != NULL);
+	assert(hdr_canon != NULL);
+	assert(body_canon != NULL);
 
 	token = strtok_r(tag, "/", &last);
 	code = arc_name_to_code(canonicalizations, token);

--- a/libopenarc/arc-canon.h
+++ b/libopenarc/arc-canon.h
@@ -52,4 +52,6 @@ extern int arc_canon_selecthdrs __P((ARC_MESSAGE *, u_char *,
                                      struct arc_hdrfield **, int));
 extern ARC_STAT arc_canon_signature __P((ARC_MESSAGE *, struct arc_hdrfield *, _Bool));
 
+extern ARC_STAT arc_parse_canon_t(unsigned char *, arc_canon_t *, arc_canon_t *);
+
 #endif /* ! _ARC_CANON_H_ */

--- a/libopenarc/arc-util.c
+++ b/libopenarc/arc-util.c
@@ -917,7 +917,7 @@ arc_copy_array(char **in)
 	out = malloc(sizeof(char *) * (n + 1));
 	if (out == NULL)
 		return NULL;
-	
+
 	for (c = 0; c < n; c++)
 	{
 		out[c] = strdup(in[c]);

--- a/libopenarc/arc.c
+++ b/libopenarc/arc.c
@@ -2386,7 +2386,8 @@ arc_eoh(ARC_MESSAGE *msg)
 	ARC_KVSET *set;
 	u_char *inst;
 	u_char *htag;
-	arc_canon_t hdr_canon, body_canon;
+	arc_canon_t hdr_canon;
+	arc_canon_t body_canon;
 
 	if (msg->arc_state >= ARC_STATE_EOH)
 		return ARC_STAT_INVALID;
@@ -2523,14 +2524,22 @@ arc_eoh(ARC_MESSAGE *msg)
 		else
 			hashtype = ARC_HASHTYPE_SHA256;
 
-		status = arc_parse_canon_t(arc_param_get(h->hdr_data, "c"),
-		                           &hdr_canon, &body_canon);
-
-		if (status != ARC_STAT_OK)
+		u_char *c = arc_param_get(h->hdr_data, "c");
+		if (c != NULL)
 		{
-			arc_error(msg,
-			          "failed to parse header c= tag");
-			return status;
+			status = arc_parse_canon_t(arc_param_get(h->hdr_data, "c"),
+						   &hdr_canon, &body_canon);
+
+			if (status != ARC_STAT_OK)
+			{
+				arc_error(msg,
+					  "failed to parse header c= tag with value %s",
+					  c);
+				return status;
+			}
+		} else {
+			hdr_canon = ARC_CANON_SIMPLE
+			body_canon = ARC_CANON_SIMPLE
 		}
 
 		status = arc_add_canon(msg, ARC_CANONTYPE_HEADER, hdr_canon,

--- a/libopenarc/arc.c
+++ b/libopenarc/arc.c
@@ -2538,8 +2538,8 @@ arc_eoh(ARC_MESSAGE *msg)
 				return status;
 			}
 		} else {
-			hdr_canon = ARC_CANON_SIMPLE
-			body_canon = ARC_CANON_SIMPLE
+			hdr_canon = ARC_CANON_SIMPLE;
+			body_canon = ARC_CANON_SIMPLE;
 		}
 
 		status = arc_add_canon(msg, ARC_CANONTYPE_HEADER, hdr_canon,

--- a/libopenarc/arc.c
+++ b/libopenarc/arc.c
@@ -2386,6 +2386,7 @@ arc_eoh(ARC_MESSAGE *msg)
 	ARC_KVSET *set;
 	u_char *inst;
 	u_char *htag;
+	arc_canon_t hdr_canon, body_canon;
 
 	if (msg->arc_state >= ARC_STATE_EOH)
 		return ARC_STAT_INVALID;
@@ -2507,25 +2508,35 @@ arc_eoh(ARC_MESSAGE *msg)
 	}
 
 	/*
-	**  Request specific canonicalizations we want to run.
+	** Request specific canonicalizations we want to run.
 	*/
 
-	/* headers, validation */
 	h = NULL;
 	htag = NULL;
 	if (nsets > 0)
 	{
+		/* headers, validation */
 		h = msg->arc_sets[nsets - 1].arcset_ams;
 		htag = arc_param_get(h->hdr_data, "h");
-
 		if (strcmp(arc_param_get(h->hdr_data, "a"), "rsa-sha1") == 0)
 			hashtype = ARC_HASHTYPE_SHA1;
 		else
 			hashtype = ARC_HASHTYPE_SHA256;
 
-		status = arc_add_canon(msg, ARC_CANONTYPE_HEADER, msg->arc_canonhdr,
+		status = arc_parse_canon_t(arc_param_get(h->hdr_data, "c"),
+		                           &hdr_canon, &body_canon);
+
+		if (status != ARC_STAT_OK)
+		{
+			arc_error(msg,
+			          "failed to parse header c= tag");
+			return status;
+		}
+
+		status = arc_add_canon(msg, ARC_CANONTYPE_HEADER, hdr_canon,
 		                       hashtype, htag, h, (ssize_t) -1,
 		                       &msg->arc_valid_hdrcanon);
+
 		if (status != ARC_STAT_OK)
 		{
 			arc_error(msg,
@@ -2534,9 +2545,10 @@ arc_eoh(ARC_MESSAGE *msg)
 		}
 
 		/* body, validation */
-		status = arc_add_canon(msg, ARC_CANONTYPE_BODY, msg->arc_canonbody,
+		status = arc_add_canon(msg, ARC_CANONTYPE_BODY, body_canon,
 		                       hashtype, NULL, NULL, (ssize_t) -1,
 		                       &msg->arc_valid_bodycanon);
+
 		if (status != ARC_STAT_OK)
 		{
 			arc_error(msg,


### PR DESCRIPTION
Parses the canonicalization header on the inbound and uses the appropriate canonicalization for validation -simple or relaxed as specified for each of the headers and body.