### PR TITLE
Feature ignore unknown methods

### DIFF
--- a/openarc/openarc.c
+++ b/openarc/openarc.c
@@ -3517,6 +3517,8 @@ mlfi_eom(SMFICTX *ctx)
 
 				for (n = 0; n < ar.ares_count; n++)
 				{
+					if (ar.ares_result[n].result_method == -1)
+						continue;
 					if (ar.ares_result[n].result_method == ARES_METHOD_ARC &&
 					    BITSET(ARC_MODE_SIGN,
 					           cc->cctx_mode) &&


### PR DESCRIPTION
If authentication milter put into the header "Authentication-Results" some method which is not defined in openarc-ar.c, we should not put "(null)=pass" or "(null)=softfail" into "ARC-Authentication-Results" header, to avoid creating non-valid ARC headers which cause problems like that of the  [issue #31 of OpenDMARC](https://github.com/trusteddomainproject/OpenDMARC/issues/31). 