### PR TITLE
Add human readable name of chain state to info message.

### DIFF
--- a/openarc/openarc.c
+++ b/openarc/openarc.c
@@ -3526,9 +3526,12 @@ mlfi_eom(SMFICTX *ctx)
 						if (conf->conf_dolog)
 						{
 							syslog(LOG_INFO,
-							       "%s: chain state forced to %d due to prior result found",
+							       "%s: chain state forced to \"%s\" due to prior result found",
 							       afc->mctx_jobid,
-							       cv);
+							       cv == ARC_CHAIN_PASS ? "pass" :
+							       cv == ARC_CHAIN_FAIL ? "fail" :
+							       cv == ARC_CHAIN_NONE ? "none" :
+							       "unknown");
 						}
 
 						arc_set_cv(afc->mctx_arcmsg,

--- a/openarc/openarc.c
+++ b/openarc/openarc.c
@@ -3523,19 +3523,15 @@ mlfi_eom(SMFICTX *ctx)
 							break;
 						}
 
+						arc_set_cv(afc->mctx_arcmsg,
+							   cv);
+
 						if (conf->conf_dolog)
 						{
 							syslog(LOG_INFO,
 							       "%s: chain state forced to \"%s\" due to prior result found",
-							       afc->mctx_jobid,
-							       cv == ARC_CHAIN_PASS ? "pass" :
-							       cv == ARC_CHAIN_FAIL ? "fail" :
-							       cv == ARC_CHAIN_NONE ? "none" :
-							       "unknown");
+							       afc->mctx_jobid, arc_chain_str(afc->mctx_arcmsg));
 						}
-
-						arc_set_cv(afc->mctx_arcmsg,
-						           cv);
 					}
 
 					arcf_dstring_printf(afc->mctx_tmpstr,


### PR DESCRIPTION
The message "chain state forced to 1 due to prior result found"
contains an internal enum index rather than the name of the
chain state. Replace with the human readable meaning.