### PR TITLE
Add ‘UMask’ parameter

### DIFF
--- a/openarc/openarc-config.h
+++ b/openarc/openarc-config.h
@@ -52,6 +52,7 @@ struct configdef arcf_config[] =
 	{ "Syslog",			CONFIG_TYPE_BOOLEAN,	FALSE },
 	{ "SyslogFacility",		CONFIG_TYPE_STRING,	FALSE },
 	{ "TemporaryDirectory",		CONFIG_TYPE_STRING,	FALSE },
+	{ "UMask",			CONFIG_TYPE_INTEGER,	FALSE },
 	{ "UserID",			CONFIG_TYPE_STRING,	FALSE },
 	{ NULL,				(u_int) -1,		FALSE }
 };

--- a/openarc/openarc.c
+++ b/openarc/openarc.c
@@ -4413,6 +4413,8 @@ main(int argc, char **argv)
 			                  sizeof pidfile);
 		}
 
+		(void) config_get(cfg, "UMask", &filemask, sizeof filemask);
+
 		if (become == NULL)
 		{
 			(void) config_get(cfg, "Userid", &become,

--- a/openarc/openarc.conf.5.in
+++ b/openarc/openarc.conf.5.in
@@ -241,6 +241,17 @@ allowed in
 The default is "mail".
 
 .TP
+.I UMask (integer)
+Requests a specific permissions mask to be used for file creation.
+This only applies to creation of the socket when
+.I Socket
+specifies a UNIX domain socket, and to the
+.I PidFile
+(if any).  See
+.I umask(2)
+for more information.
+
+.TP
 .I UserID (string)
 Attempts to become the specified userid before starting operations.
 The value is of the form

--- a/openarc/openarc.conf.sample
+++ b/openarc/openarc.conf.sample
@@ -271,6 +271,15 @@ Syslog			Yes
 
 # TemporaryDirectory	/tmp
 
+##  UMask mask
+##  	default (none)
+##
+##  Change the process umask for file creation to the specified value.
+##  The system has its own default which will be used (usually 022).
+##  See the umask(2) man page for more information.
+
+# UMask			022
+
 ##  Userid userid
 ##  	default (none)
 ##


### PR DESCRIPTION
The proposed change adds the missing parameter `UMask`. The logic setting `umask` is already there, so all that is needed is reading the parameter from the configuration, and including some documentation (copied from OpenDKIM).