### PR TITLE
Quote results in Authentication-Results if necessary

### DIFF
--- a/libopenarc/arc.c
+++ b/libopenarc/arc.c
@@ -3711,7 +3711,7 @@ arc_chain_custody_str(ARC_MESSAGE *msg, u_char *buf, size_t buflen)
 		kvset = msg->arc_sets[set].arcset_ams->hdr_data;
 		str = arc_param_get(kvset, "d");
 		(void) arc_dstring_printf(tmpbuf, "%s%s",
-		                          (set < msg->arc_nsets ? ":" : ""),
+		                          (set < msg->arc_nsets - 1 ? ":" : ""),
 		                          str);
 	}
 

--- a/openarc/openarc.c
+++ b/openarc/openarc.c
@@ -3851,14 +3851,24 @@ mlfi_eom(SMFICTX *ctx)
 
 		if (ipout != NULL)
 		{
+			_Bool quote = strchr(ipout, ':') != NULL;
+
 			arcf_dstring_printf(afc->mctx_tmpstr,
-			                    " smtp.remote-ip=%s", ipout);
+			                    " smtp.remote-ip=%s%s%s",
+			                    quote ? "\"" : "",
+			                    ipout,
+			                    quote ? "\"" : "");
 		}
 
 		if (conf->conf_finalreceiver && arcchainlen > 0)
 		{
+			_Bool quote = strchr(arcchainbuf, ':') != NULL;
+
 			arcf_dstring_printf(afc->mctx_tmpstr,
-			                    " arc.chain=%s", arcchainbuf);
+			                    " arc.chain=%s%s%s",
+			                    quote ? "\"" : "",
+			                    arcchainbuf,
+			                    quote ? "\"" : "");
 		}
 
 		if (arcf_insheader(ctx, 1, AUTHRESULTSHDR,


### PR DESCRIPTION
The proposed change fixes a bug where OpenARC produces syntactically invalid `Authentication-Results` headers, by applying quoting to the result values where appropriate. It also fixes an off-by-one error when producing the `arc.chain` result value.

This fixes #143.