### PR TITLE
Add human readable name of chain state to info message (develop)

### DIFF
--- a/openarc/openarc.c
+++ b/openarc/openarc.c
@@ -3705,16 +3705,15 @@ mlfi_eom(SMFICTX *ctx)
 							break;
 						}
 
+						arc_set_cv(afc->mctx_arcmsg,
+							   cv);
+
 						if (conf->conf_dolog)
 						{
 							syslog(LOG_INFO,
-							       "%s: chain state forced to %d due to prior result found",
-							       afc->mctx_jobid,
-							       cv);
+							       "%s: chain state forced to \"%s\" due to prior result found",
+							       afc->mctx_jobid, arc_chain_status_str(afc->mctx_arcmsg));
 						}
-
-						arc_set_cv(afc->mctx_arcmsg,
-						           cv);
 					}
 
 					if (arcf_dstring_len(afc->mctx_tmpstr) > 0)


### PR DESCRIPTION
The message "chain state forced to 1 due to prior result found" contains an internal enum index rather than the name of the chain state. Replace with the human readable meaning.

Replaces https://github.com/trusteddomainproject/OpenARC/pull/138