### PR TITLE
fix header canonicalization eol wrap

### DIFF
--- a/libopenarc/arc.c
+++ b/libopenarc/arc.c
@@ -671,8 +671,8 @@ arc_getamshdr_d(ARC_MESSAGE *msg, size_t initial, u_char **buf, size_t *buflen,
 							                 ':');
 							len += 1;
 							arc_dstring_catn(msg->arc_hdrbuf,
-							                 (u_char *) "\n\t ",
-							                 3);
+							                 (u_char *) "\n ",
+							                 2);
 							len = 9;
 							arc_dstring_catn(msg->arc_hdrbuf,
 							                 (u_char *) tmp,
@@ -719,8 +719,8 @@ arc_getamshdr_d(ARC_MESSAGE *msg, size_t initial, u_char **buf, size_t *buflen,
 						if (msg->arc_margin - len == 0)
 						{
 							arc_dstring_catn(msg->arc_hdrbuf,
-							                  (u_char *) "\n\t ",
-							                  3);
+							                  (u_char *) "\n ",
+							                  2);
 							len = 9;
 						}
 

--- a/libopenarc/arc.c
+++ b/libopenarc/arc.c
@@ -673,7 +673,7 @@ arc_getamshdr_d(ARC_MESSAGE *msg, size_t initial, u_char **buf, size_t *buflen,
 							arc_dstring_catn(msg->arc_hdrbuf,
 							                 (u_char *) "\n ",
 							                 2);
-							len = 9;
+							len = 8;
 							arc_dstring_catn(msg->arc_hdrbuf,
 							                 (u_char *) tmp,
 							                 tmplen);
@@ -721,7 +721,7 @@ arc_getamshdr_d(ARC_MESSAGE *msg, size_t initial, u_char **buf, size_t *buflen,
 							arc_dstring_catn(msg->arc_hdrbuf,
 							                  (u_char *) "\n ",
 							                  2);
-							len = 9;
+							len = 8;
 						}
 
 						n = MIN(msg->arc_margin - len,


### PR DESCRIPTION
https://www.rfc-editor.org/rfc/rfc8617#section-4.1.3
https://www.rfc-editor.org/rfc/rfc6376#section-3.4.2

EOL termination states single WSP when canonicalizing header fields using tab x09 or space x20, not both

X-Amavis-Alert: BAD HEADER SECTION, Improper folded header field made up
    entirely of whitespace (char 09 20 hex): ARC-Message-Signature:

