### PR TITLE
Fix invalid ARC-Seal when email contains existing sets

### DIFF
--- a/libopenarc/arc.c
+++ b/libopenarc/arc.c
@@ -2912,8 +2912,8 @@ arc_eoh(ARC_MESSAGE *msg)
 		return ARC_STAT_SYNTAX;
 	}
 
-	if ((msg->arc_mode & ARC_MODE_VERIFY) != 0 &&
-	    msg->arc_cstate != ARC_CHAIN_FAIL)
+	/* need to verify previous sets even if running in sign mode */
+	if (msg->arc_cstate != ARC_CHAIN_FAIL)
 	{
 		status = arc_canon_runheaders_seal(msg);
 		if (status != ARC_STAT_OK)


### PR DESCRIPTION
When creating the ARC-Seal, any existing sets in the email must be included in the seal. See https://www.rfc-editor.org/rfc/rfc8617#section-5.1.1

The existing code does not include existing sets and is thus creating invalid signatures in these circumstances. This PR includes them.