### PR TITLE
autoconf.ac: Remove obsolete macros and fix AC_OUTPUT

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -12,8 +12,8 @@ AC_PREREQ(2.61)
 #
 # Package version
 #
-m4_define([VERSION_RELEASE], 1)
-m4_define([VERSION_MAJOR_REV], 0)
+m4_define([VERSION_RELEASE], 0)
+m4_define([VERSION_MAJOR_REV], 1)
 m4_define([VERSION_MINOR_REV], 0)
 m4_define([VERSION_PATCH], 0)
 
@@ -36,14 +36,12 @@ AC_INIT([OpenARC],
 AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE(
   1.11.1
-  dnl Automake version before 1.13 (when the serial-tests option was
-  dnl still the default) still defined the badly obsolete macro
-  dnl 'AM_PROG_INSTALL'.
-  m4_ifndef([AM_PROG_INSTALL], [serial-tests])
 )
 AC_CONFIG_HEADERS([build-config.h])
 
 AC_CONFIG_MACRO_DIR([m4])
+
+LT_INIT
 
 #
 # Hexadecimal version, for use in generating dkim.h
@@ -61,8 +59,9 @@ AC_SUBST([LIBOPENARC_VERSION_INFO])
 # Checks for programs
 #
 AC_PROG_CC
+# autoconf 2.70 deprecated this, but it might still be necessary on old versions
+m4_version_prereq([2.70], [:], [AC_PROG_CC_C99])
 AM_PROG_CC_C_O
-LT_INIT
 
 PKG_PROG_PKG_CONFIG
 
@@ -665,7 +664,6 @@ then
 	CPPFLAGS="$saved_CPPFLAGS"
 	LDFLAGS="$saved_LDFLAGS"
 	LIBS="$saved_LIBS"
-
 fi
 
 AC_SUBST(LIBCRYPTO_CFLAGS)
@@ -795,82 +793,6 @@ AC_SUBST(LIBMILTER_INCDIRS)
 AC_SUBST(LIBMILTER_LIBDIRS)
 AC_SUBST(LIBMILTER_LIBS)
 
-#
-# header filtering requires libjansson
-# 
-
-AC_ARG_WITH([libjansson],
-            AS_HELP_STRING([--with-libjansson],
-                           [location of jansson includes and library]),
-            [janssonpath="$withval"], [janssonpath="auto"])
-
-LIBJANSSON_CPPFLAGS=""
-LIBJANSSON_LDFLAGS=""
-LIBJANSSON_LIBS=""
-
-jansson_found="no"
-if test \( x"$janssonpath" = x"auto" -o x"$janssonpath" = x"yes" \) -a \
-	x"$PKG_CONFIG" != x""
-then
-        PKG_CHECK_MODULES([LIBJANSSON], [jansson >= 2.2.1],
-	[
-		jansson_found="yes"
-		LIBJANSSON_CPPFLAGS="$LIBJANSSON_CFLAGS"
-		LIBJANSSON_LIBS="$LIBJANSSON_LIBS"
-	],
-	[
-	        jansson_found="no"
-        	AC_MSG_WARN([pkg-config for libjansson not found, trying manual
-		            search...])
-        ])
-fi
-
-if test x"$janssonpath" != x"no" -a x"$jansson_found" = x"no"
-then
-	AC_MSG_CHECKING([for libjansson])
-	if test x"$janssonpath" != x"auto" -a x"$janssonpath" != x"yes"
-	then
-		if test -f $janssonpath/include/jansson.h
-		then
-			AC_MSG_RESULT($janssonpath)
-		        jansson_found="yes"
-			LIBJANSSON_CPPFLAGS="-I$janssonpath/include"
-			LIBJANSSON_LDFLAGS="-L$janssonpath/lib"
-			LIBJANSSON_LIBS="-ljansson"
-		else
-			AC_MSG_ERROR(not found at $janssonpath)
-		fi
-	else
-		janssondirs="/usr /usr/local"
-		for d in $janssondirs
-		do
-			if test -f $d/include/jansson.h
-			then
-				janssonpath=$d
-				AC_MSG_RESULT($d)
-		        	jansson_found="yes"
-				LIBJANSSON_CPPFLAGS="-I$janssonpath/include"
-				LIBJANSSON_LDFLAGS="-L$janssonpath/lib"
-				LIBJANSSON_LIBS="-ljansson"
-				break
-			fi
-		done
-	fi
-	if test x"$jansson_found" != x"yes"
-	then
-		AC_MSG_RESULT([no])
-	fi
-fi
-AC_SUBST(LIBJANSSON_CPPFLAGS)
-AC_SUBST(LIBJANSSON_LDFLAGS)
-AC_SUBST(LIBJANSSON_LIBS)
-AM_CONDITIONAL(JANSSON, test x"$LIBJANSSON_LIBS" != x"")
-
-if test x"$jansson_found" == x"yes"
-then
-	AC_DEFINE(USE_JANSSON, 1, [use libjansson to provide header field checks])
-fi
-
 # This (below) is just for the pkg-config file openarc.pc.in
 LIBOPENARC_LIBS_PKG="$LIBOPENARC_LIBS"
 LIBOPENARC_INC="$LIBCRYPTO_CPPFLAGS $LIBCRYPTO_CFLAGS $LIBTRE_CPPFLAGS"
@@ -960,62 +882,30 @@ SYSCONFDIR=`eval echo "$sysconfdir"`
 AC_SUBST([SYSCONFDIR])
 
 #
-# for contrib/spec/openarc.spec.in
-#
-
-installbin="no"
-specconfig=""
-specrequires=""
-specbuildrequires=""
-
-SPECBINDIR=""
-if test x"$installbin" = x"yes"
-then
-	SPECBINDIR="%{_bindir}/*"
-fi
-
-SPECCONFIGURE="$specconfig"
-
-if test x"$specrequires" = x""
-then
-	SPECREQUIRES=""
-else
-	SPECREQUIRES="Requires:$specrequires"
-fi
-
-if test x"$specbuildrequires" = x""
-then
-	SPECBUILDREQUIRES=""
-else
-	SPECBUILDREQUIRES="BuildRequires:$specbuildrequires"
-fi
-
-AC_SUBST(SPECBINDIR)
-AC_SUBST(SPECCONFIGURE)
-AC_SUBST(SPECREQUIRES)
-AC_SUBST(SPECBUILDREQUIRES)
-
-#
 # Finish up
 #
 
-AC_OUTPUT([	Makefile
-		docs/Makefile
-		contrib/Makefile
-			contrib/docs/Makefile
-			contrib/init/Makefile
-			contrib/init/generic/Makefile
-			contrib/init/redhat/Makefile
-			contrib/init/redhat/openarc
-			contrib/init/solaris/Makefile
-			contrib/spec/Makefile
-			contrib/spec/openarc.spec
-			contrib/systemd/Makefile
-			contrib/systemd/openarc.service
-		libopenarc/openarc.pc libopenarc/Makefile
-		libopenarc/docs/Makefile
-		openarc/Makefile openarc/openarc.8 openarc/openarc.conf.5
-			openarc/openarc.conf.simple
+AC_CONFIG_FILES([
+    Makefile
+    docs/Makefile
+    contrib/Makefile
+    contrib/docs/Makefile
+    contrib/init/Makefile
+    contrib/init/generic/Makefile
+    contrib/init/redhat/Makefile
+    contrib/init/redhat/openarc
+    contrib/init/solaris/Makefile
+    contrib/spec/Makefile
+    contrib/spec/openarc.spec
+    contrib/systemd/Makefile
+    contrib/systemd/openarc.service
+    libopenarc/openarc.pc
+    libopenarc/Makefile
+    libopenarc/docs/Makefile
+    openarc/Makefile
+    openarc/openarc.8
+    openarc/openarc.conf.5
+    openarc/openarc.conf.simple
 ])
-		#libopenarc/tests/Makefile
-		#openarc/tests/Makefile
+
+AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -7,7 +7,7 @@
 #
 # Setup
 #
-AC_PREREQ(2.71)
+AC_PREREQ(2.61)
 
 #
 # Package version
@@ -38,8 +38,8 @@ AM_INIT_AUTOMAKE(
   1.11.1
   dnl Automake version before 1.13 (when the serial-tests option was
   dnl still the default) still defined the badly obsolete macro
-  dnl 'AC_PROG_INSTALL'.
-  m4_ifndef([AC_PROG_INSTALL], [serial-tests])
+  dnl 'AM_PROG_INSTALL'.
+  m4_ifndef([AM_PROG_INSTALL], [serial-tests])
 )
 AC_CONFIG_HEADERS([build-config.h])
 
@@ -61,9 +61,7 @@ AC_SUBST([LIBOPENARC_VERSION_INFO])
 # Checks for programs
 #
 AC_PROG_CC
-# AC_PROG_CC_C99
 AM_PROG_CC_C_O
-# AC_PROG_LIBTOOL
 LT_INIT
 
 PKG_PROG_PKG_CONFIG

--- a/configure.ac
+++ b/configure.ac
@@ -7,7 +7,7 @@
 #
 # Setup
 #
-AC_PREREQ(2.61)
+AC_PREREQ(2.71)
 
 #
 # Package version
@@ -38,8 +38,8 @@ AM_INIT_AUTOMAKE(
   1.11.1
   dnl Automake version before 1.13 (when the serial-tests option was
   dnl still the default) still defined the badly obsolete macro
-  dnl 'AM_PROG_INSTALL'.
-  m4_ifndef([AM_PROG_INSTALL], [serial-tests])
+  dnl 'AC_PROG_INSTALL'.
+  m4_ifndef([AC_PROG_INSTALL], [serial-tests])
 )
 AC_CONFIG_HEADERS([build-config.h])
 
@@ -61,9 +61,10 @@ AC_SUBST([LIBOPENARC_VERSION_INFO])
 # Checks for programs
 #
 AC_PROG_CC
-AC_PROG_CC_C99
+# AC_PROG_CC_C99
 AM_PROG_CC_C_O
-AC_PROG_LIBTOOL
+# AC_PROG_LIBTOOL
+LT_INIT
 
 PKG_PROG_PKG_CONFIG
 


### PR DESCRIPTION
This updates the `configure.ac` file to work with newer versions (2.71+) of `autoconf` to generate a `configure` file.