### PR TITLE
Remove unused buffer 'confstr' in arcf_config_load

### DIFF
--- a/openarc/openarc.c
+++ b/openarc/openarc.c
@@ -1384,14 +1384,12 @@ arcf_config_load(struct config *data, struct arcf_config *conf,
 	int dbflags = 0;
 	uint64_t fixedtime = 0UL;
 	char *str;
-	char confstr[BUFRSZ + 1];
 	char basedir[MAXPATHLEN + 1];
 
 	assert(conf != NULL);
 	assert(err != NULL);
 
 	memset(basedir, '\0', sizeof basedir);
-	memset(confstr, '\0', sizeof confstr);
 
 	str = NULL;
 	if (data != NULL)


### PR DESCRIPTION
The buffer `confstr` has been existed since the file was added, however it has been never used.  For readability of the code, I'd like to remove it.