### PR TITLE
libopenarc: Check length of header field name tightly.

### DIFF
--- a/libopenarc/arc.c
+++ b/libopenarc/arc.c
@@ -2412,7 +2412,7 @@ arc_parse_header_field(ARC_MESSAGE *msg, u_char *hdr, size_t hlen,
 		end--;
 
 	/* don't allow incredibly large field names */
-	if (end - hdr > ARC_MAXHEADER)
+	if (end - hdr > ARC_MAXHDRNAMELEN)
 		return ARC_STAT_SYNTAX;
 
 	/* don't allow a field name containing a semicolon */
@@ -2762,8 +2762,8 @@ arc_eoh(ARC_MESSAGE *msg)
 
 	for (h = msg->arc_hhead; h != NULL; h = h->hdr_next)
 	{
-		char hnbuf[ARC_MAXHEADER + 1];
-		assert(h->hdr_namelen <= ARC_MAXHEADER);
+		char hnbuf[ARC_MAXHDRNAMELEN + 1];
+		assert(h->hdr_namelen <= ARC_MAXHDRNAMELEN);
 
 		memset(hnbuf, '\0', sizeof hnbuf);
 		strncpy(hnbuf, h->hdr_text, h->hdr_namelen);

--- a/libopenarc/arc.c
+++ b/libopenarc/arc.c
@@ -2407,6 +2407,10 @@ arc_parse_header_field(ARC_MESSAGE *msg, u_char *hdr, size_t hlen,
 	while (end > hdr && isascii(*(end - 1)) && isspace(*(end - 1)))
 		end--;
 
+	/* don't allow incredibly large field names */
+	if (end - hdr > ARC_MAXHEADER)
+		return ARC_STAT_SYNTAX;
+
 	/* don't allow a field name containing a semicolon */
 	semicolon = memchr(hdr, ';', hlen);
 	if (semicolon != NULL && colon != NULL && semicolon < colon)
@@ -2755,6 +2759,7 @@ arc_eoh(ARC_MESSAGE *msg)
 	for (h = msg->arc_hhead; h != NULL; h = h->hdr_next)
 	{
 		char hnbuf[ARC_MAXHEADER + 1];
+		assert(h->hdr_namelen <= ARC_MAXHEADER);
 
 		memset(hnbuf, '\0', sizeof hnbuf);
 		strncpy(hnbuf, h->hdr_text, h->hdr_namelen);

--- a/libopenarc/arc.h
+++ b/libopenarc/arc.h
@@ -46,6 +46,8 @@ extern "C" {
 #define ARC_HDRMARGIN		75	/* "standard" header margin */
 #define ARC_MAXHEADER		4096	/* buffer for caching one header */
 #define	ARC_MAXHOSTNAMELEN	256	/* max. FQDN we support */
+#define ARC_MAXLINELEN		1000	/* physical line limit (RFC5321) */
+#define ARC_MAXHDRNAMELEN	(ARC_MAXLINELEN - 3) /* deduct ":" CRLF */
 
 #define	ARC_AR_HDRNAME		"ARC-Authentication-Results"
 #define	ARC_DEFAULT_MINKEYSIZE	1024


### PR DESCRIPTION
From the restriction of RFC5322 section 2.1.1 and section 2.2, length of email header field name cannot be more than 997.
    
With this PR,  we define a constant macro for it, and then apply this restriction on parsing header field. Also,  reduce size of a buffer for copying header field name.

This PR contains PR #117.