### PR TITLE
openarc: Avoid truncate ARC set headers

### DIFF
--- a/openarc/openarc.c
+++ b/openarc/openarc.c
@@ -3788,7 +3788,7 @@ mlfi_eom(SMFICTX *ctx)
 			size_t len;
 			u_char *hfvdest;
 			u_char hfname[BUFRSZ + 1];
-			u_char hfvalue[BUFRSZ + 1];
+			u_char hfvalue[ARC_MAXHEADER + 1];
 
 			memset(hfname, '\0', sizeof hfname);
 			strlcpy(hfname, arc_hdr_name(sealhdr, &len),


### PR DESCRIPTION
As ARC set header may grow up to ARC_MAXHEADER, the limit size per header size we determined to handle, buffer size to store should be larger than it.

With this commit, fix a size of the buffer to store header field body.

This would fix the problem described in PR #161